### PR TITLE
Add github actions for build tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,7 +41,7 @@ jobs:
           echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
           echo "compression = true" >> ~/.ccache/ccache.conf
           echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 400M" >> ~/.ccache/ccache.conf
+          echo "max_size = 800M" >> ~/.ccache/ccache.conf
           ccache -s
           ccache -z
     - name: release_build_test
@@ -62,6 +62,6 @@ jobs:
         rosdep update
         rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
         catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
-        catkin build -j$(nproc) -l$(nproc) aerial_mapper
+        catkin build -j$(nproc) -l$(nproc) aerial_mapper -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
     - name: ccache post-run
       run: ccache -s

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,67 @@
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: ccache cache files
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: sitl_tests-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+        restore-keys: sitl_tests-ccache-
+    - name: setup ccache
+      run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 6" >> ~/.ccache/ccache.conf
+          echo "max_size = 400M" >> ~/.ccache/ccache.conf
+          ccache -s
+          ccache -z
+    - name: release_build_test
+      working-directory: 
+      run: |
+        apt update
+        apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        wstool init src src/aerial_mapper/install/dependencies_https.rosinstall
+        wstool update -t src -j4
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+        catkin build -j$(nproc) -l$(nproc) aerial_mapper
+    - name: ccache post-run
+      run: ccache -s

--- a/aerial_mapper_io/src/aerial-mapper-io.cc
+++ b/aerial_mapper_io/src/aerial-mapper-io.cc
@@ -251,10 +251,10 @@ void AerialMapperIO::loadImagesFromFile(
 aslam::NCamera::Ptr AerialMapperIO::loadCameraRigFromFile(
     const std::string& filename_ncameras_yaml) {
   CHECK(filename_ncameras_yaml != "");
-  aslam::NCamera::Ptr ncameras;
+  aslam::NCamera::Ptr ncameras(new aslam::NCamera());
   LOG(INFO) << "Loading camera calibration from: "
             << filename_ncameras_yaml;
-  ncameras = aslam::NCamera::loadFromYaml(filename_ncameras_yaml);
+  ncameras->deserializeFromFile(filename_ncameras_yaml);
   CHECK(ncameras) << "Could not load the camera calibration from: "
                   << filename_ncameras_yaml;
  return ncameras;

--- a/install/dependencies_https.rosinstall
+++ b/install/dependencies_https.rosinstall
@@ -13,3 +13,9 @@
 - git: {local-name: pcl_catkin, uri: 'https://github.com/ethz-asl/pcl_catkin.git'}
 - git: {local-name: vision_opencv, uri: 'https://github.com/ethz-asl/vision_opencv.git'}
 - git: {local-name: yaml_cpp_catkin, uri: 'https://github.com/ethz-asl/yaml_cpp_catkin.git'}
+- git: {local-name: protobuf_catkin, uri: 'https://github.com/ethz-asl/protobuf_catkin.git'}
+- git: {local-name: ethzasl_apriltag2, uri: 'https://github.com/ethz-asl/ethzasl_apriltag2.git'}
+- git: {local-name: numpy_eigen, uri: 'https://github.com/ethz-asl/numpy_eigen.git'}
+- git: {local-name: libnabo, uri: 'https://github.com/ethz-asl/libnabo.git'}
+- git: {local-name: catkin_boost_python_buildtool, uri: 'https://github.com/ethz-asl/catkin_boost_python_buildtool.git'}
+- git: {local-name: opengv, uri: 'https://github.com/ethz-asl/opengv.git'}


### PR DESCRIPTION
**Problem Description**
This PR adds a github actions pipeline for evaluating build tests of the `aerial_mapper` project.

**Additional Context**
- The default branch has switched to `develop` on this fork, therefore the PR https://github.com/Jaeyoung-Lim/aerial_mapper/pull/1 has been reopened
- The build time is currently approximately 1 hour and this is due to all the dependencies. We need to reduce this by having a prebuilt container of the workspace