### PR TITLE
Add a docker environment for building the package

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,58 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
-          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
-          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-08-20'}
-    container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: sitl_tests-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: sitl_tests-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 800M" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
     - name: release_build_test
-      working-directory: 
       run: |
-        apt update
-        apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev
-        mkdir -p $HOME/catkin_ws/src;
-        cd $HOME/catkin_ws
-        catkin init
-        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
-        catkin config --merge-devel
-        cd $HOME/catkin_ws/src
-        ln -s $GITHUB_WORKSPACE
-        cd $HOME/catkin_ws
-        wstool init src src/aerial_mapper/install/dependencies_https.rosinstall
-        wstool update -t src -j4
-        rosdep update
-        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
-        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
-        catkin build -j$(nproc) -l$(nproc) aerial_mapper -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    - name: ccache post-run
-      run: ccache -s
+        make build

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ push:
 
 publish: build push
 publish-base: build-base push-base
+
+run:
+	docker run -it --rm ethzasl/aerial_mapper:${version} /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+version?=latest
+
+build-base:
+	docker build -f aerial_mapper/docker/Dockerfile.base --tag ethzasl/aerial_mapper:base-${version} .
+
+push-base:
+	docker push ethzasl/aerial_mapper:base-${version}
+
+build:
+	docker build -f aerial_mapper/docker/Dockerfile --tag ethzasl/aerial_mapper:${version} .
+
+push:
+	docker push ethzasl/aerial_mapper:${version}
+
+publish: build push
+publish-base: build-base push-base

--- a/aerial_mapper/docker/Dockerfile
+++ b/aerial_mapper/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ethzasl/aerial_mapper:base-latest
+ENV HOME=/root
+
+#Build Dependencies
+COPY . $HOME/catkin_ws/src/aerial_mapper/
+RUN catkin build -j$(nproc) -l$(nproc) aerial_mapper -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/aerial_mapper/docker/Dockerfile.base
+++ b/aerial_mapper/docker/Dockerfile.base
@@ -1,0 +1,19 @@
+FROM px4io/px4-dev-ros-melodic:2020-08-14 as build-env
+
+ENV HOME=/root
+
+RUN apt update && apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev
+RUN mkdir -p $HOME/catkin_ws/src;
+WORKDIR $HOME/catkin_ws
+RUN catkin init
+RUN catkin config --extend "/opt/ros/melodic" && catkin config --merge-devel
+
+#Install Dependencies
+COPY . $HOME/catkin_ws/src/aerial_mapper/
+RUN wstool init src src/aerial_mapper/install/dependencies_https.rosinstall
+RUN wstool update -t src -j4
+RUN rosdep update && rosdep install --from-paths src --ignore-src -y --rosdistro melodic
+RUN catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+FROM build-env
+RUN catkin build -j$(nproc) -l$(nproc) aerial_mapper -DCMAKE_CXX_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
**Problem Description**
This package takes about ~70min to build on github actions. This is highly inefficient and unnecessary. Therefore a docker environment is added so that we can speed up the builds.
- The intention is to pre-build all the dependencies and build the `aerial_mapper` after that to speed up the build time
- This also provides a contained environment for development