### PR TITLE
Link xhost to container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ publish: build push
 publish-base: build-base push-base
 
 run:
-	docker run -it --rm ethzasl/aerial_mapper:${version} /bin/bash
+	xhost local:root
+	docker run -it --rm -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ethzasl/aerial_mapper:${version} /bin/bash

--- a/aerial_mapper/docker/Dockerfile.base
+++ b/aerial_mapper/docker/Dockerfile.base
@@ -2,7 +2,7 @@ FROM px4io/px4-dev-ros-melodic:2020-08-14 as build-env
 
 ENV HOME=/root
 
-RUN apt update && apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev
+RUN apt update && apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev libgtk2.0-dev
 RUN mkdir -p $HOME/catkin_ws/src;
 WORKDIR $HOME/catkin_ws
 RUN catkin init


### PR DESCRIPTION
**Problem Description**
Since the package is best verified using a visual representation, using gui applications from the container is useful.

This adds a `make run` instruction so that a `aerial_mapper_demos` package can run properly

![image](https://user-images.githubusercontent.com/5248102/107406747-0d7b6380-6b09-11eb-8dfe-56f25b63357e.png)


**Next steps**
This still "copies" the code base into the container, which is not desirable since any local code changes will not make it into the container. Therefore we need to use bind volumes in order to get it working properly. 
