### PR TITLE
Run aerial_mapper with PX4 SITL

### DIFF
--- a/aerial_mapper_sitl/CMakeLists.txt
+++ b/aerial_mapper_sitl/CMakeLists.txt
@@ -1,4 +1,27 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(aerial_mapper_sitl)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+
+find_package(catkin_simple REQUIRED)
+catkin_simple(ALL_DEPS_REQUIRED)
+
+#############
+# LIBRARIES #
+#############
+add_definitions(-std=c++11)
+
+cs_add_executable(${PROJECT_NAME}
+  src/simulation_node.cc
+  src/simulation.cc
+)
+
+#############
+# QTCREATOR #
+#############
+FILE(GLOB_RECURSE LibFiles "include/*")
+add_custom_target(headers SOURCES ${LibFiles})
+  
+##########
+# EXPORT #
+##########
+cs_install()
+cs_export()

--- a/aerial_mapper_sitl/CMakeLists.txt
+++ b/aerial_mapper_sitl/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(aerial_mapper_sitl)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/aerial_mapper_sitl/README.md
+++ b/aerial_mapper_sitl/README.md
@@ -1,0 +1,2 @@
+# aerial_mapper_sitl
+Integration of `aerial_mapper` in a Software-In-The-Loop simulation with PX4

--- a/aerial_mapper_sitl/include/aerial_mapper_sitl/simulation.h
+++ b/aerial_mapper_sitl/include/aerial_mapper_sitl/simulation.h
@@ -1,0 +1,73 @@
+#ifndef AERIAL_MAPPER_SITL_SIMULATION_H
+#define AERIAL_MAPPER_SITL_SIMULATION_H
+
+#include "ros/callback_queue.h"
+#include <ros/ros.h>
+#include <pcl/filters/filter.h>
+#include <pcl_conversions/pcl_conversions.h>  // fromROSMsg
+#include <pcl_ros/point_cloud.h>
+#include <pcl_ros/transforms.h>  // transformPointCloud
+#include <sensor_msgs/PointCloud2.h>
+#include <aerial-mapper-utils/utils-nearest-neighbor.h>
+#include <mutex>
+
+#include <aerial-mapper-dsm/dsm.h>
+#include <aerial-mapper-grid-map/aerial-mapper-grid-map.h>
+#include <aerial-mapper-io/aerial-mapper-io.h>
+#include <aerial-mapper-utils/utils-nearest-neighbor.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+class Simulation {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  Simulation(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  ~Simulation();
+
+  void init();
+  // void getPointClouds(AlignedType<std::vector, Eigen::Vector3d>::type* point_cloud);
+
+ private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ros::Publisher pointcloud_pub_;
+
+  ros::Subscriber pointcloud_sub_;
+
+  ros::Time last_time_;
+
+  tf::TransformListener tf_listener_;
+
+  ros::Timer cmdloop_timer_, statusloop_timer_;
+  ros::CallbackQueue cmdloop_queue_, statusloop_queue_;
+  std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
+  std::unique_ptr<ros::AsyncSpinner> statusloop_spinner_;
+
+  double cmdloop_dt_{0.1};
+  double statusloop_dt_{1.0};
+
+  AlignedType<std::vector, Eigen::Vector3d>::type point_cloud_;
+
+  grid_map::Settings settings_aerial_grid_map_;
+  dsm::Settings settings_dsm_;
+  std::unique_ptr<grid_map::AerialGridMap> grid_map_;
+  std::unique_ptr<dsm::Dsm> dsm_;
+
+  std::recursive_mutex mutex_;
+
+  /**
+  * @brief     callaback for command loop timer
+  * @param[in] even, ROS events
+  **/
+  void cmdLoopCallback(const ros::TimerEvent& event);
+
+  /**
+  * @brief     callaback for status loop timer
+  * @param[in] even, ROS events
+  **/
+  void statusLoopCallback(const ros::TimerEvent& event);
+
+  void pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg);
+};
+#endif  // AERIAL_MAPPER_SITL_SIMULATION_H

--- a/aerial_mapper_sitl/launch/px4-sitl.launch
+++ b/aerial_mapper_sitl/launch/px4-sitl.launch
@@ -30,7 +30,7 @@
 
   <include file="$(find px4)/launch/posix_sitl.launch">
       <arg name="vehicle" value="$(arg mav_name)"/>
-      <arg name="sdf" value="$(find mavlink_sitl_gazebo)/models/$(arg model)/$(arg model).sdf"/>
+      <arg name="sdf" value="$(find aerial_mapper_sitl)/models/$(arg model)/$(arg model).sdf"/>
   </include>
 
 <node pkg="rviz" type="rviz" name="rviz" args="-d $(find aerial_mapper_sitl)/rviz/px4_sitl.rviz"/>

--- a/aerial_mapper_sitl/launch/px4-sitl.launch
+++ b/aerial_mapper_sitl/launch/px4-sitl.launch
@@ -1,0 +1,38 @@
+<launch>
+  <arg name="mav_name" default="techpod"/>
+  <arg name="model" default="techpod_depth_camera"/>
+  <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
+  <arg name="gcs_url" default="" />
+  <arg name="tgt_system" default="1" />
+  <arg name="tgt_component" default="1" />
+  <arg name="command_input" default="2" />
+  <arg name="gazebo_simulation" default="true" />
+  <arg name="visualization" default="true"/>
+  <arg name="log_output" default="screen" />
+  <arg name="fcu_protocol" default="v2.0" />
+  <arg name="respawn_mavros" default="false" />
+
+<node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
+          args="0 0 0 1.57 3.14158 0 fcu camera_link 10"/>
+  
+  <include file="$(find mavros)/launch/node.launch">
+      <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
+      <arg name="config_yaml" value="$(find aerial_mapper_sitl)/launch/px4_config.yaml" />
+
+      <arg name="fcu_url" value="$(arg fcu_url)" />
+      <arg name="gcs_url" value="$(arg gcs_url)" />
+      <arg name="tgt_system" value="$(arg tgt_system)" />
+      <arg name="tgt_component" value="$(arg tgt_component)" />
+      <arg name="log_output" value="$(arg log_output)" />
+      <arg name="fcu_protocol" value="$(arg fcu_protocol)" />
+      <arg name="respawn_mavros" default="$(arg respawn_mavros)" />
+  </include>
+
+  <include file="$(find px4)/launch/posix_sitl.launch">
+      <arg name="vehicle" value="$(arg mav_name)"/>
+      <arg name="sdf" value="$(find mavlink_sitl_gazebo)/models/$(arg model)/$(arg model).sdf"/>
+  </include>
+
+<node pkg="rviz" type="rviz" name="rviz" args="-d $(find aerial_mapper_sitl)/rviz/px4_sitl.rviz"/>
+
+</launch>

--- a/aerial_mapper_sitl/launch/px4-sitl.launch
+++ b/aerial_mapper_sitl/launch/px4-sitl.launch
@@ -11,9 +11,12 @@
   <arg name="log_output" default="screen" />
   <arg name="fcu_protocol" default="v2.0" />
   <arg name="respawn_mavros" default="false" />
+  <arg name="flagfile" default="$(find aerial_mapper_demos)/flags/0-synthetic-cadastre-dsm.ff" />
 
-<node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
-          args="0 0 0 1.57 3.14158 0 fcu camera_link 10"/>
+  <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
+            args="0 0 0 1.57 3.14158 0 fcu camera_link 10"/>
+  <node pkg="tf" type="static_transform_publisher" name="world_local"
+            args="0 0 0 0 0 0 world local_origin 10"/>
   
   <include file="$(find mavros)/launch/node.launch">
       <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
@@ -33,6 +36,7 @@
       <arg name="sdf" value="$(find aerial_mapper_sitl)/models/$(arg model)/$(arg model).sdf"/>
   </include>
 
-<node pkg="rviz" type="rviz" name="rviz" args="-d $(find aerial_mapper_sitl)/rviz/px4_sitl.rviz"/>
+  <node pkg="aerial_mapper_sitl" type="aerial_mapper_sitl" name="demo_sitl" output="screen" args="--flagfile=$(arg flagfile)" />
 
+  <node pkg="rviz" type="rviz" name="rviz" args="-d $(find aerial_mapper_sitl)/rviz/px4_sitl.rviz"/>
 </launch>

--- a/aerial_mapper_sitl/launch/px4_config.yaml
+++ b/aerial_mapper_sitl/launch/px4_config.yaml
@@ -1,0 +1,184 @@
+# Common configuration for PX4 autopilot
+#
+# node:
+startup_px4_usb_quirk: true
+
+# --- system plugins ---
+
+# sys_status & sys_time connection options
+conn:
+  heartbeat_rate: 1.0    # send hertbeat rate in Hertz
+  timeout: 10.0          # hertbeat timeout in seconds
+  timesync_rate: 10.0    # TIMESYNC rate in Hertz (feature disabled if 0.0)
+  system_time_rate: 1.0  # send system time to FCU rate in Hertz (disabled if 0.0)
+
+# sys_status
+sys:
+  min_voltage: 10.0   # diagnostics min voltage
+  disable_diag: false # disable all sys_status diagnostics, except heartbeat
+
+# sys_time
+time:
+  time_ref_source: "fcu"  # time_reference source
+  timesync_avg_alpha: 0.6 # timesync averaging factor
+
+# --- mavros plugins (alphabetical order) ---
+
+# 3dr_radio
+tdr_radio:
+  low_rssi: 40  # raw rssi lower level for diagnostics
+
+# actuator_control
+# None
+
+# command
+cmd:
+  use_comp_id_system_control: false # quirk for some old FCUs
+
+# dummy
+# None
+
+# ftp
+# None
+
+# global_position
+global_position:
+  frame_id: "fcu"           # pose and fix frame_id
+  rot_covariance: 99999.0   # covariance for attitude?
+  tf:
+    send: false               # send TF?
+    frame_id: "local_origin"  # TF frame_id
+    child_frame_id: "fcu_utm" # TF child_frame_id
+
+# imu_pub
+imu:
+  frame_id: "fcu"
+  # need find actual values
+  linear_acceleration_stdev: 0.0003
+  angular_velocity_stdev: 0.0003490659 // 0.02 degrees
+  orientation_stdev: 1.0
+  magnetic_stdev: 0.0
+
+# local_position
+local_position:
+  frame_id: "local_origin"
+  tf:
+    send: true
+    frame_id: "local_origin"
+    child_frame_id: "fcu"
+    send_fcu: false
+
+# param
+# None, used for FCU params
+
+# rc_io
+# None
+
+# safety_area
+safety_area:
+  p1: {x:  1.0, y:  1.0, z:  1.0}
+  p2: {x: -1.0, y: -1.0, z: -1.0}
+
+# setpoint_accel
+setpoint_accel:
+  send_force: false
+
+# setpoint_attitude
+setpoint_attitude:
+  reverse_throttle: false   # allow reversed throttle
+  tf:
+    listen: false           # enable tf listener (disable topic subscribers)
+    frame_id: "local_origin"
+    child_frame_id: "attitude"
+    rate_limit: 10.0
+
+# setpoint_position
+setpoint_position:
+  tf:
+    listen: false           # enable tf listener (disable topic subscribers)
+    frame_id: "local_origin"
+    child_frame_id: "setpoint"
+    rate_limit: 50.0
+
+# setpoint_velocity
+# None
+
+# vfr_hud
+# None
+
+# waypoint
+mission:
+  pull_after_gcs: true  # update mission if gcs updates
+
+# --- mavros extras plugins (same order) ---
+
+# distance_sensor (PX4 only)
+distance_sensor:
+  hrlv_ez4_pub:
+    id: 0
+    frame_id: "hrlv_ez4_sonar"
+    orientation: ROLL_180 # RPY:{180.0, 0.0, 0.0}
+    field_of_view: 0.0  # XXX TODO
+    send_tf: true
+    sensor_position: {x:  0.0, y:  0.0, z:  -0.1}
+  lidarlite_pub:
+    id: 1
+    frame_id: "lidarlite_laser"
+    orientation: ROLL_180
+    field_of_view: 0.0  # XXX TODO
+    send_tf: true
+    sensor_position: {x:  0.0, y:  0.0, z:  -0.1}
+  sonar_1_sub:
+    subscriber: true
+    id: 2
+    orientation: ROLL_180
+  laser_1_sub:
+    subscriber: true
+    id: 3
+    orientation: ROLL_180
+
+## Currently available orientations:
+#    Check http://wiki.ros.org/mavros/Enumerations
+##
+
+# image_pub
+image:
+  frame_id: "px4flow"
+
+# mocap_pose_estimate
+mocap:
+  # select mocap source
+  use_tf: true   # ~mocap/tf
+  use_pose: false  # ~mocap/pose
+
+
+# odom
+odometry:
+  fcu:
+    odom_parent_id_des: "map"    # desired parent frame rotation of the FCU's odometry
+    odom_child_id_des: "base_link"    # desired child frame rotation of the FCU's odometry
+
+# px4flow
+px4flow:
+  frame_id: "px4flow"
+  ranger_fov: 0.118682      # 6.8 degrees at 5 meters, 31 degrees at 1 meter
+  ranger_min_range: 0.3     # meters
+  ranger_max_range: 5.0     # meters
+
+# vision_pose_estimate
+vision_pose:
+  tf:
+    listen: false           # enable tf listener (disable topic subscribers)
+    frame_id: "local_origin"
+    child_frame_id: "vision"
+    rate_limit: 10.0
+
+# vision_speed_estimate
+vision_speed:
+  listen_twist: false
+
+# vibration
+vibration:
+  frame_id: "vibration"
+
+# vim:set ts=2 sw=2 et:

--- a/aerial_mapper_sitl/models/techpod_depth_camera/model.config
+++ b/aerial_mapper_sitl/models/techpod_depth_camera/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>Tecpod model with depthcamera</name>
+  <version>1.0</version>
+  <sdf>techpod_depth_camera.sdf</sdf>
+
+  <author>
+   <name>Jaeyoung Lim</name>
+   <email>jalim@ethz.ch</email>
+  </author>
+
+  <description>
+    This is a model of the Tecpod Fixedwing airplane with a depth camera
+  </description>
+</model>

--- a/aerial_mapper_sitl/models/techpod_depth_camera/techpod_depth_camera.sdf
+++ b/aerial_mapper_sitl/models/techpod_depth_camera/techpod_depth_camera.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<sdf version='1.5'>
+  <model name='tecpod_depth_camera'>
+    <include>
+      <uri>model://techpod</uri>
+    </include> 
+    <include>
+      <uri>model://depth_camera</uri>
+      <pose>0.1 0 0 0 1.5708 0</pose>
+    </include>
+    <joint name="depth_camera_joint" type="revolute">
+      <child>depth_camera::link</child>
+      <parent>techpod::base_link</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <upper>0</upper>
+          <lower>0</lower>
+        </limit>
+      </axis>
+    </joint>
+  </model>
+</sdf>
+

--- a/aerial_mapper_sitl/models/techpod_depth_camera/techpod_depth_camera.sdf
+++ b/aerial_mapper_sitl/models/techpod_depth_camera/techpod_depth_camera.sdf
@@ -4,12 +4,64 @@
     <include>
       <uri>model://techpod</uri>
     </include> 
-    <include>
-      <uri>model://depth_camera</uri>
+    <link name="depth_camera_link">
       <pose>0.1 0 0 0 1.5708 0</pose>
-    </include>
+      <inertial>
+        <pose>0.01 0.025 0.025 0 0 0</pose>
+        <mass>0.01</mass>
+        <inertia>
+          <ixx>4.15e-6</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2.407e-6</iyy>
+          <iyz>0</iyz>
+          <izz>2.407e-6</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>model://realsense_camera/meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <sensor name="depth_camera" type="depth">
+        <update_rate>20</update_rate>
+        <camera>
+          <horizontal_fov>1.02974</horizontal_fov>
+          <image>
+            <format>R8G8B8</format>
+            <width>64</width>
+            <height>48</height>
+          </image>
+          <clip>
+            <near>0.5</near>
+            <far>20</far>
+          </clip>
+        </camera>
+        <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
+          <cameraName>camera</cameraName>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>20</updateRate>
+          <pointCloudCutoff>0.2</pointCloudCutoff>
+          <pointCloudCutoffMax>18</pointCloudCutoffMax>
+          <imageTopicName>rgb/image_raw</imageTopicName>
+          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <frameName>camera_link</frameName>
+          <distortion_k1>0.0</distortion_k1>
+          <distortion_k2>0.0</distortion_k2>
+          <distortion_k3>0.0</distortion_k3>
+          <distortion_t1>0.0</distortion_t1>
+          <distortion_t2>0.0</distortion_t2>
+        </plugin>
+      </sensor>
+    </link>
     <joint name="depth_camera_joint" type="revolute">
-      <child>depth_camera::link</child>
+      <child>depth_camera_link</child>
       <parent>techpod::base_link</parent>
       <axis>
         <xyz>0 0 1</xyz>
@@ -21,4 +73,3 @@
     </joint>
   </model>
 </sdf>
-

--- a/aerial_mapper_sitl/package.xml
+++ b/aerial_mapper_sitl/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>aerial_mapper_sitl</name>
+  <version>0.0.1</version>
+  <description>aerial_mapper_sitl</description>
+  <maintainer email="jalim@ethz.ch">Jaeyoung Lim</maintainer>
+  <author email="jalim@ethz.ch">Jaeyoung Lim</author>
+  <license>BSD</license>
+  
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+
+  <depend>aerial_mapper_dense_pcl</depend>
+  <depend>aerial_mapper_dsm</depend>
+  <depend>aerial_mapper_google_maps_api</depend>
+  <depend>aerial_mapper_grid_map</depend>
+  <depend>aerial_mapper_io</depend>
+  <depend>aerial_mapper_ortho</depend>
+  <depend>aerial_mapper_utils</depend>
+  <depend>aslam_cv_cameras</depend>
+  <depend>aslam_cv_common</depend>
+  <depend>aslam_cv_frames</depend>
+  <depend>aslam_cv_pipeline</depend>
+  <depend>camera_info_manager</depend>
+  <depend>cmake_modules</depend>
+  <depend>cv_bridge</depend>
+  <depend>eigen_catkin</depend>
+  <depend>gflags_catkin</depend>
+  <depend>glog_catkin</depend>
+  <depend>image_transport</depend>
+  <depend>minkindr_conversions</depend>
+  <depend>pcl_catkin</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+
+</package>

--- a/aerial_mapper_sitl/rviz/px4_sitl.rviz
+++ b/aerial_mapper_sitl/rviz/px4_sitl.rviz
@@ -1,0 +1,169 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /Grid1/Offset1
+        - /PointCloud21
+        - /Axes1
+        - /Axes2
+      Splitter Ratio: 0.570231020450592
+    Tree Height: 907
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 5
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 30
+      Reference Frame: local_origin
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.5
+      Style: Points
+      Topic: /camera/depth/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 10
+      Name: Axes
+      Radius: 1
+      Reference Frame: local_origin
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 5
+      Name: Axes
+      Radius: 0.5
+      Reference Frame: fcu
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 255; 255; 255
+    Default Light: true
+    Fixed Frame: local_origin
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 287.5182800292969
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -11.226810455322266
+        Y: -14.82934856414795
+        Z: 40.01042175292969
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.3248000741004944
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.986459970474243
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1052
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001d1000003c6fc0200000017fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000003c6000000c700fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007300000001df000000a30000005c00fffffffb0000000800540069006d0065000000023d000000590000003700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d0061006700650000000337000000910000000000000000fb0000000c00430061006d006500720061000000031b000000160000000000000000fb0000000c00430061006d0065007200610000000320000000160000000000000000fb0000000c00430061006d00650072006100000003ec000000160000000000000000fb0000000c00430061006d00650072006103000002b40000011a000002f60000021cfb0000000a0049006d00610067006500000003c60000001b0000000000000000fb0000000c00430061006d00650072006101000002780000016e0000000000000000fb0000000c00430061006d00650072006100000003ce000000160000000000000000fb0000000c00430061006d00650072006100000003ec000000160000000000000000fb0000000c00430061006d00650072006100000003ec000000160000000000000000fb0000000c00430061006d0065007200610000000334000000ce0000000000000000fb0000000c00430061006d00650072006100000003ec000000160000000000000000fb0000000c00430061006d006500720061010000020b000001d90000000000000000fb0000000a0049006d00610067006500000003e60000001c0000000000000000000000010000010f000003befc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000003be000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000003bfc0100000001fb0000000800540069006d00650100000000000004500000000000000000000005a9000003c600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 232
+  Y: 0

--- a/aerial_mapper_sitl/rviz/px4_sitl.rviz
+++ b/aerial_mapper_sitl/rviz/px4_sitl.rviz
@@ -11,6 +11,8 @@ Panels:
         - /PointCloud21
         - /Axes1
         - /Axes2
+        - /GridMap1
+        - /PointCloud22
       Splitter Ratio: 0.570231020450592
     Tree Height: 907
   - Class: rviz/Selection
@@ -82,7 +84,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.5
       Style: Points
-      Topic: /camera/depth/points
+      Topic: /planar_rectification/point_cloud
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -100,6 +102,57 @@ Visualization Manager:
       Name: Axes
       Radius: 0.5
       Reference Frame: fcu
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Class: grid_map_rviz_plugin/GridMap
+      Color: 200; 200; 200
+      Color Layer: elevation
+      Color Transformer: GridMapLayer
+      Enabled: true
+      Height Layer: elevation
+      Height Transformer: GridMapLayer
+      History Length: 1
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 10
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: GridMap
+      Show Grid Lines: true
+      Topic: /grid_map
+      Unreliable: false
+      Use Rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic: /camera/depth/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
       Value: true
   Enabled: true
   Global Options:
@@ -129,25 +182,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 287.5182800292969
+      Distance: 222.65414428710938
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -11.226810455322266
-        Y: -14.82934856414795
-        Z: 40.01042175292969
+        X: -1.9806214570999146
+        Y: -31.01276969909668
+        Z: 35.432212829589844
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.3248000741004944
+      Pitch: 0.48980051279067993
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 2.986459970474243
+      Yaw: 3.6264567375183105
     Saved: ~
 Window Geometry:
   Displays:

--- a/aerial_mapper_sitl/src/simulation.cc
+++ b/aerial_mapper_sitl/src/simulation.cc
@@ -1,0 +1,101 @@
+
+#include "aerial_mapper_sitl/simulation.h"
+#include <tf_conversions/tf_eigen.h>
+
+Simulation::Simulation(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private)
+    : nh_(nh), nh_private_(nh_private) {
+
+  settings_aerial_grid_map_.center_easting = 0.0;
+  settings_aerial_grid_map_.center_northing = 0.0;
+  settings_aerial_grid_map_.delta_easting = 200.0;
+  settings_aerial_grid_map_.delta_northing = 200.0;
+  settings_aerial_grid_map_.resolution = 0.5;
+  grid_map_ = std::make_unique<grid_map::AerialGridMap>(settings_aerial_grid_map_);
+
+  LOG(INFO) << "Create DSM (batch).";
+  settings_dsm_.center_easting = settings_aerial_grid_map_.center_easting;
+  settings_dsm_.center_northing = settings_aerial_grid_map_.center_northing;
+  dsm_ = std::make_unique<dsm::Dsm>(settings_dsm_, grid_map_->getMutable());
+}
+
+Simulation::~Simulation() {}
+
+void Simulation::init() {
+  last_time_ = ros::Time::now();
+  ros::TimerOptions cmdlooptimer_options(ros::Duration(cmdloop_dt_),
+                                         boost::bind(&Simulation::cmdLoopCallback, this, _1), &cmdloop_queue_);
+  cmdloop_timer_ = nh_.createTimer(cmdlooptimer_options);
+
+  ros::TimerOptions statuslooptimer_options(
+      ros::Duration(statusloop_dt_), boost::bind(&Simulation::statusLoopCallback, this, _1), &statusloop_queue_);
+  statusloop_timer_ = nh_.createTimer(statuslooptimer_options);
+
+  pointcloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &Simulation::pointCloudCallback, this);
+  pointcloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2>("/camera/depth/transformed_points", 1);
+
+  cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
+  cmdloop_spinner_->start();
+  statusloop_spinner_.reset(new ros::AsyncSpinner(1, &statusloop_queue_));
+  statusloop_spinner_->start();
+}
+
+void Simulation::cmdLoopCallback(const ros::TimerEvent& event) {}
+
+void Simulation::statusLoopCallback(const ros::TimerEvent& event) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  if (point_cloud_.empty()) {
+    return;
+  }
+  dsm_->process(point_cloud_, grid_map_->getMutable());
+  grid_map_->publishOnce();
+
+  std::cout << "Cleared pointclouds" << std::endl;
+  point_cloud_.clear();
+}
+
+void Simulation::pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  ros::Time current_time = ros::Time::now();
+  if ((current_time - last_time_).toSec() < 0.05) {
+    return;
+  }
+
+  //Transform the pointcloud into world frame
+  pcl::PointCloud<pcl::PointXYZ> untransformed_cloud;
+  pcl::PointCloud<pcl::PointXYZ> transformed_cloud;
+
+  //First, lookup the transform
+  tf::StampedTransform transform;
+  try{
+    tf_listener_.lookupTransform( "/local_origin", "/camera_link", ros::Time(0), transform);
+  }
+  catch (tf::TransformException ex){
+    ROS_ERROR("%s",ex.what());
+    return;
+  }
+
+  Eigen::Affine3d transform_1;
+  tf::poseTFToEigen(transform, transform_1);
+
+  pcl::fromROSMsg(*msg, untransformed_cloud);
+
+  //Second, transform the pointcloud into the world frame
+  pcl::transformPointCloud(untransformed_cloud, transformed_cloud, transform_1);
+
+  //Verify that the tranform is correct
+  sensor_msgs::PointCloud2 transformed_pt_msg;
+  transformed_pt_msg.header.stamp = ros::Time::now();
+  pcl::toROSMsg(transformed_cloud, transformed_pt_msg);
+  transformed_pt_msg.header.frame_id = "local_origin";
+  pointcloud_pub_.publish(transformed_pt_msg);
+
+  //TODO: Accumulate pointclouds here
+  for (pcl::PointCloud<pcl::PointXYZ>::const_iterator it = transformed_cloud.begin();
+   it != transformed_cloud.end(); ++it) {
+    Eigen::Vector3d point(it->x, it->y, it->z);
+    point_cloud_.push_back(point);
+  }
+  last_time_ = current_time;
+}

--- a/aerial_mapper_sitl/src/simulation_node.cc
+++ b/aerial_mapper_sitl/src/simulation_node.cc
@@ -1,0 +1,36 @@
+/*
+ *    Filename: simulation_node.cpp
+ *  Created on: Mar 17, 2021
+ *      Author: Jaeyoung Lim
+ *   Institute: ETH Zurich, Autonomous Systems Lab
+ */
+
+// NON-SYSTEM
+#include <aerial-mapper-dense-pcl/stereo.h>
+#include <aerial-mapper-dsm/dsm.h>
+#include <aerial-mapper-grid-map/aerial-mapper-grid-map.h>
+#include <aerial-mapper-io/aerial-mapper-io.h>
+#include <aerial-mapper-utils/utils-nearest-neighbor.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include "aerial_mapper_sitl/simulation.h"
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InstallFailureSignalHandler();
+
+  ros::init(argc, argv, "aerial_mapper_sitl");
+
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
+
+  Simulation simulation_node(nh, nh_private);
+  simulation_node.init();
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
**Problem Description**
This PR adds a new package, `aerial_mapper_sitl` to run `aerial_mapper` with a PX4 SITL(Software-In-The-Loop) simulation.

The added changes are
- rviz configs to visualize the pointclouds correctly and tf publishing configured on the mavros side for visualization
- Added a `techpod_depth_camera` model

**Testing**
![techpod](https://user-images.githubusercontent.com/5248102/111195216-52892e80-85bc-11eb-9229-e93e892bfa9d.gif)

**Additional Context**